### PR TITLE
Include private repos when retrieving issues and PRs

### DIFF
--- a/actions/lib/github_issues.py
+++ b/actions/lib/github_issues.py
@@ -46,9 +46,13 @@ def get_issues_and_prs_for_repo(repo, time_delta):
     return result
 
 
-def get_issues_and_prs_for_user(github_user, time_delta):
+def get_issues_and_prs_for_user(github_user, time_delta, repo_type='all'):
     """
     Retrieve issues and PRs for all the Github repos for the provided user.
+
+    :param repo_type: Type of repos to query for the isssues (all, public, private, forks,
+                      sources, member).
+    :type repo_type: ``str``
     """
     result = {
         'username': github_user.login.replace('-', '_').lower(),
@@ -57,7 +61,9 @@ def get_issues_and_prs_for_user(github_user, time_delta):
         'pulls': []
     }
 
-    for repo in github_user.get_repos():
+    for repo in github_user.get_repos(type=repo_type):
+        print repo
+        continue
         repo_result = get_issues_and_prs_for_repo(repo=repo, time_delta=time_delta)
         result['issues'].extend(repo_result['issues'])
         result['pulls'].extend(repo_result['pulls'])

--- a/actions/lib/github_issues.py
+++ b/actions/lib/github_issues.py
@@ -62,8 +62,6 @@ def get_issues_and_prs_for_user(github_user, time_delta, repo_type='all'):
     }
 
     for repo in github_user.get_repos(type=repo_type):
-        print repo
-        continue
         repo_result = get_issues_and_prs_for_repo(repo=repo, time_delta=time_delta)
         result['issues'].extend(repo_result['issues'])
         result['pulls'].extend(repo_result['pulls'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyGithub==1.43.4
+PyGithub==1.43.5
 Jinja2==2.10
 feedparser==5.2.1


### PR DESCRIPTION
This change will update the action to also include private repos when listing issues and PRs.

Keep in mind that we also need to update the access token we use so it can access the private repos.