### PR TITLE
Fix data escaping

### DIFF
--- a/actions/assemble_message.py
+++ b/actions/assemble_message.py
@@ -50,4 +50,15 @@ class AssembleMessageAction(Action):
         # Add all information to the template context and render the template
         env = Environment(trim_blocks=True, lstrip_blocks=True)
         rendered = env.from_string(template_data).render(template_context)
+
+        # Remove any Jinja and YAQL expressions to prevent them from trying to be rendered inside
+        # the workflow
+        rendered = rendered.replace('{%', '').replace('%}', '')
+        rendered = rendered.replace('{{', '').replace('}}', '')
+        rendered = rendered.replace('<%', '').replace('%>', '')
+        rendered = rendered.replace('\\"', '"').replace("\'", "'")
+
+        # Also escape no-valid unicode escape sequences
+        rendered = rendered.replace('\\', '')
+
         return rendered

--- a/actions/lib/github_issues.py
+++ b/actions/lib/github_issues.py
@@ -43,6 +43,10 @@ def get_issues_and_prs_for_repo(repo, time_delta):
         else:
             result['issues'].append(issue_dict)
 
+        # Remove fields which we don't need to spin things up
+        if 'body' in issue_dict:
+            del issue_dict['body']
+
     return result
 
 

--- a/actions/workflows/retrieve_data_and_send_daily_stats_to_slack.yaml
+++ b/actions/workflows/retrieve_data_and_send_daily_stats_to_slack.yaml
@@ -43,7 +43,7 @@ tasks:
         do:
           - send_message_to_slack
         publish:
-          - message: <% result().result %>
+          - message: "<% result().result %>"
   send_message_to_slack:
     action: slack.chat.postMessage
     input:

--- a/rules/post_daily_summary_to_slack.yaml
+++ b/rules/post_daily_summary_to_slack.yaml
@@ -9,7 +9,7 @@ trigger:
   parameters:
     timezone: "UTC"
     day_of_week: '*'
-    hour: 17
+    hour: 15
     minute: 30
     second: 0
 


### PR DESCRIPTION
Data we dynamically retrieve can contain YAQL and / or Jinja expressions and this would break the workflow because it would try to render published variables as YAQL / Jinja expressions (and this would fail).

This pull request "fixes" that by escaping data inside the action (it's really a workaround, I think Orquesta should support escape / "treat it as raw string" functionality for variables).

Related issue - https://github.com/StackStorm/st2/issues/4636